### PR TITLE
Added FromAddress and FromName to ExactTargetTriggeredEmail class to be able to specify sender information in a triggered email.

### DIFF
--- a/ExactTarget.TriggeredEmail/Trigger/ExactTargetTriggeredEmail.cs
+++ b/ExactTarget.TriggeredEmail/Trigger/ExactTargetTriggeredEmail.cs
@@ -20,27 +20,39 @@ namespace ExactTarget.TriggeredEmail.Trigger
             ReplacementValues = new Dictionary<string, string>();
         }
 
+        /// <summary>
+        /// Specifies the sender email address. 
+        /// Both FromAddress and FromName must be specified to set the email sender field.
+        /// </summary>
+        public string FromAddress { get; set; }
+
+        /// <summary>
+        /// Specifies the sender name.
+        /// Both FromAddress and FromName must be specified to set the email sender field.
+        /// </summary>
+        public string FromName { get; set; }
+
         public string EmailAddress { get; private set; }
 
         public string SubscriberKey { get; set; }
 
-        public string ExternalKey { get; private set;}
+        public string ExternalKey { get; private set; }
 
         public Dictionary<string, string> ReplacementValues { get; private set; }
 
         public ExactTargetTriggeredEmail AddReplacementValue(string key, string value)
-         {
-             ReplacementValues[key] = value;
-             return this;
-         }
+        {
+            ReplacementValues[key] = value;
+            return this;
+        }
 
         public ExactTargetTriggeredEmail AddReplacementValues(IEnumerable<KeyValuePair<string, string>> tags)
-         {
-             foreach (var pair in tags)
-             {
-                 AddReplacementValue(pair.Key, pair.Value);
-             }
-             return this;
-         }
+        {
+            foreach (var pair in tags)
+            {
+                AddReplacementValue(pair.Key, pair.Value);
+            }
+            return this;
+        }
     }
 }


### PR DESCRIPTION
I needed to specify the sender email address when I send triggered emails so I needed these two properties to set Subscriber.Owner. 

Official doco here under the section "Determining the From Information at Send Time":
https://help.exacttarget.com/en/technical_library/web_service_guide/triggered_email_scenario_guide_for_developers/#Determining_the_From_Information_at_Send_Time
