### PR TITLE
Exception handling when triggering email sends

### DIFF
--- a/ExactTarget.TriggeredEmail/Core/Exceptions/ExactTargetException.cs
+++ b/ExactTarget.TriggeredEmail/Core/Exceptions/ExactTargetException.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace ExactTarget.TriggeredEmail.Core.Exceptions
+{
+    public class ExactTargetException : Exception
+    {
+        public ExactTargetException()
+        {
+        }
+
+        public ExactTargetException(string message) : base(message)
+        {
+        }
+
+        public ExactTargetException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/ExactTarget.TriggeredEmail/Core/Exceptions/SubscriberExcludedException.cs
+++ b/ExactTarget.TriggeredEmail/Core/Exceptions/SubscriberExcludedException.cs
@@ -1,0 +1,29 @@
+﻿namespace ExactTarget.TriggeredEmail.Core.Exceptions
+{
+    public class SubscriberExcludedException : ExactTargetException
+    {
+        private readonly string _emailAddress;
+        private readonly string _additionalInfo;
+
+        public SubscriberExcludedException(string emailAddress)
+        {
+            _emailAddress = emailAddress;
+        }
+
+        public SubscriberExcludedException(string emailAddress, string additionalInfo)
+        {
+            _emailAddress = emailAddress;
+            _additionalInfo = additionalInfo;
+        }
+
+        public string EmailAddress
+        {
+            get { return _emailAddress; }
+        }
+
+        public override string Message
+        {
+            get { return string.Format("Subcriber was excluded. EmailAddress: {0} Additional Info: {1}", _emailAddress, _additionalInfo); }
+        }
+    }
+}

--- a/ExactTarget.TriggeredEmail/ExactTarget.TriggeredEmail.csproj
+++ b/ExactTarget.TriggeredEmail/ExactTarget.TriggeredEmail.csproj
@@ -45,6 +45,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Core\EmailContentHelper.cs" />
+    <Compile Include="Core\Exceptions\ExactTargetException.cs" />
+    <Compile Include="Core\Exceptions\SubscriberExcludedException.cs" />
     <Compile Include="Core\RequestClients\DeliveryProfile\DeliveryProfileClient.cs" />
     <Compile Include="Core\RequestClients\DeliveryProfile\IDeliveryProfileClient.cs" />
     <Compile Include="Core\SoapClientFactory.cs" />


### PR DESCRIPTION
Introduced ExactTarget exception types. Throwing a SubscriberExcludedException when ExactTarget returns an error code of 24 (subscriber excluded by list detective).

This is a common scenario when dealing with bad subscriber email addresses and not necessarily an application error as such. Having a specific exception for this case allows us to easily handle it differently from generic exact target errors.